### PR TITLE
Update golang-jwt library to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/rsb177/jwtauth
 go 1.15
 
 require (
-	github.com/go-chi/chi/v5 v5.0.3
-	github.com/golang-jwt/jwt/v4 v4.0.0
+	github.com/go-chi/chi/v5 v5.0.12
+	github.com/golang-jwt/jwt/v5 v5.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-chi/chi/v5 v5.0.3 h1:khYQBdPivkYG1s1TAzDQG1f6eX4kD2TItYVZexL5rS4=
-github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
-github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
+github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/jwtauth.go
+++ b/jwtauth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v5"
 )
 
 // Context keys
@@ -54,9 +54,9 @@ func NewWithParser(alg string, parser *jwt.Parser, signKey interface{}, verifyKe
 // Verifier http middleware handler will verify a JWT string from a http request.
 //
 // Verifier will search for a JWT token in a http request, in the order:
-//   1. 'jwt' URI query parameter
-//   2. 'Authorization: BEARER T' request header
-//   3. Cookie 'jwt' value
+//  1. 'jwt' URI query parameter
+//  2. 'Authorization: BEARER T' request header
+//  3. Cookie 'jwt' value
 //
 // The first JWT string that is found as a query parameter, authorization header
 // or cookie header is then decoded by the `jwt-go` library and a *jwt.Token
@@ -105,15 +105,6 @@ func VerifyRequest(ja *JWTAuth, r *http.Request, findTokenFns ...func(r *http.Re
 	// Verify the token
 	token, err := ja.Decode(tokenStr)
 	if err != nil {
-		if verr, ok := err.(*jwt.ValidationError); ok {
-			if verr.Errors&jwt.ValidationErrorExpired > 0 {
-				return token, ErrExpired
-			} else if verr.Errors&jwt.ValidationErrorIssuedAt > 0 {
-				return token, ErrIATInvalid
-			} else if verr.Errors&jwt.ValidationErrorNotValidYet > 0 {
-				return token, ErrNBFInvalid
-			}
-		}
 		return token, err
 	}
 

--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -14,8 +13,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/golang-cz/jwtauth"
-	jwt "github.com/golang-jwt/jwt/v4"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/rsb177/jwtauth"
 )
 
 var (
@@ -157,8 +156,6 @@ func TestMore(t *testing.T) {
 					case jwtauth.ErrUnauthorized:
 						http.Error(w, http.StatusText(401), 401)
 						return
-					case nil:
-						// no error
 					}
 				}
 
@@ -221,7 +218,7 @@ func TestMore(t *testing.T) {
 	}
 
 	h = newAuthHeader(jwt.MapClaims{"exp": jwtauth.EpochNow() - 1000})
-	if status, resp := testRequest(t, ts, "GET", "/admin", h, nil); status != 401 || resp != "expired\n" {
+	if status, resp := testRequest(t, ts, "GET", "/admin", h, nil); status != 401 || resp != "Unauthorized\n" {
 		t.Fatalf(resp)
 	}
 
@@ -259,7 +256,7 @@ func testRequest(t *testing.T, ts *httptest.Server, method, path string, header 
 		return 0, ""
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 		return 0, ""


### PR DESCRIPTION
The purpose of this PR is to update the` golang-jwt `library to `v5`.

**Changes:**
- Validation happens a little bit differently in `v5` and we also don't have the `ValidationError`s being returned as part of it
  - Instead of manually returning the error messages based on the validation error we receive, we instead return the error itself, which is an error string describing what went wrong
- Updated the tests according to the change above